### PR TITLE
Don't bind Attr class directly.

### DIFF
--- a/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/View.kt
+++ b/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/View.kt
@@ -9,7 +9,6 @@ import androidx.core.view.updatePaddingRelative
 import androidx.databinding.BindingAdapter
 import kotlin.math.roundToInt
 import net.crimsonwoods.easydatabinding.models.Animation
-import net.crimsonwoods.easydatabinding.models.Attr
 import net.crimsonwoods.easydatabinding.models.Background
 import net.crimsonwoods.easydatabinding.models.Bool
 import net.crimsonwoods.easydatabinding.models.Color
@@ -55,34 +54,24 @@ fun View.setBackground(value: Background) = when (value) {
     is Background.Res -> {
         setBackgroundResource(value.resId)
     }
+    is Background.Attr -> {
+        when {
+            value.attr.isColor(context) -> {
+                setBackgroundColor(checkNotNull(value.attr.asColor(context)).toInt(context))
+            }
+            value.attr.isDrawable(context) -> {
+                background = checkNotNull(value.attr.asDrawable(context)).toDrawable(context)
+            }
+            else -> {
+                throw IllegalArgumentException("Unsupported attribute resource is supplied.")
+            }
+        }
+    }
     is Background.Drawable -> {
         background = value.drawable.toDrawable(context)
     }
     is Background.None -> {
         background = null
-    }
-}
-
-@BindingAdapter("android:background")
-fun View.setBackground(value: Attr) = when {
-    value.isColor(context) -> {
-        val color = value.asColor(context)
-        if (color != null) {
-            setBackgroundColor(color.toInt(context))
-        } else {
-            background = null
-        }
-    }
-    value.isDrawable(context) -> {
-        val drawable = value.asDrawable(context)
-        if (drawable != null) {
-            setBackground(drawable.toDrawable(context))
-        } else {
-            background = null
-        }
-    }
-    else -> {
-        throw IllegalArgumentException("Unsupported attribute resource is supplied.")
     }
 }
 

--- a/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/models/Background.kt
+++ b/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/models/Background.kt
@@ -1,6 +1,7 @@
 package net.crimsonwoods.easydatabinding.models
 
 import android.graphics.drawable.ColorDrawable
+import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -31,6 +32,10 @@ sealed class Background {
         val resId: Int
     ) : Background()
 
+    data class Attr(
+        val attr: net.crimsonwoods.easydatabinding.models.Attr,
+    ) : Background()
+
     data class Drawable(
         val drawable: net.crimsonwoods.easydatabinding.models.Drawable
     ) : Background()
@@ -40,6 +45,10 @@ sealed class Background {
     companion object {
         @JvmStatic
         fun of(@DrawableRes resId: Int): Background = Res(resId)
+
+        @JvmStatic
+        fun attr(@AttrRes resId: Int): Background =
+            Attr(net.crimsonwoods.easydatabinding.models.Attr.of(resId))
 
         @JvmStatic
         fun of(drawable: android.graphics.drawable.Drawable?): Background =

--- a/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/ViewBindingTest.kt
+++ b/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/ViewBindingTest.kt
@@ -32,7 +32,6 @@ import net.crimsonwoods.easydatabinding.matcher.ViewMatchers.withRotationX
 import net.crimsonwoods.easydatabinding.matcher.ViewMatchers.withRotationY
 import net.crimsonwoods.easydatabinding.matcher.ViewMatchers.withScaleX
 import net.crimsonwoods.easydatabinding.matcher.ViewMatchers.withScaleY
-import net.crimsonwoods.easydatabinding.models.Attr
 import net.crimsonwoods.easydatabinding.models.Background
 import net.crimsonwoods.easydatabinding.models.Bool
 import net.crimsonwoods.easydatabinding.models.Dimension
@@ -146,7 +145,7 @@ class ViewBindingTest {
     fun testBinding_setBackground_Attr_Drawable() {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<View>(R.id.border)
-                .setBackground(Attr.of(R.attr.selectableItemBackground))
+                .setBackground(Background.attr(R.attr.selectableItemBackground))
         }
         onView(withId(R.id.border)).check(matches(isDrawableClassOf<RippleDrawable>()))
     }
@@ -155,7 +154,7 @@ class ViewBindingTest {
     fun testBinding_setBackground_Attr_Color() {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<View>(R.id.border)
-                .setBackground(Attr.of(R.attr.colorPrimary))
+                .setBackground(Background.attr(R.attr.colorPrimary))
         }
         onView(withId(R.id.border)).check(matches(isDrawableClassOf<ColorDrawable>()))
     }


### PR DESCRIPTION
## Summary
`Attr` class should not support binding.
It should be able to use transparently as of any other resources.

## Details
- Remove a BindingAdapter for `Attr` class
- Add a helper function "fun attr(...)" on `Background` resource class
- Update UT