### PR TITLE
Supports null value binding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@
 indent_size=4
 insert_final_newline=true
 max_line_length=off
+ij_kotlin_imports_layout=*

--- a/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/ImageView.kt
+++ b/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/ImageView.kt
@@ -44,7 +44,7 @@ fun ImageView.setScaleType(value: Integer) {
 }
 
 @BindingAdapter("android:src")
-fun ImageView.setImage(image: Image) = when (image) {
+fun ImageView.setImage(image: Image?) = when (image) {
     is Image.Res -> {
         // To keep compatibility for API Level 21,
         // sets image drawable to null explicitly if given resource ID is zero.
@@ -66,9 +66,12 @@ fun ImageView.setImage(image: Image) = when (image) {
     is Image.None -> {
         setImageDrawable(null)
     }
+    null -> {
+        setImageDrawable(null)
+    }
 }
 
 @BindingAdapter("tint")
-fun ImageView.setTintList(value: Tint) {
-    ImageViewCompat.setImageTintList(this, value.toColorStateList(context))
+fun ImageView.setTintList(value: Tint?) {
+    ImageViewCompat.setImageTintList(this, value?.toColorStateList(context))
 }

--- a/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/TextView.kt
+++ b/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/TextView.kt
@@ -1,5 +1,6 @@
 package net.crimsonwoods.easydatabinding.binding
 
+import android.content.res.ColorStateList
 import android.os.Build
 import android.util.TypedValue
 import android.widget.TextView
@@ -180,8 +181,8 @@ fun TextView.setSelectAllOnFocus(value: Bool) {
 }
 
 @BindingAdapter("android:text")
-fun TextView.setText(text: Text) {
-    this.text = text.toCharSequence(resources)
+fun TextView.setText(text: Text?) {
+    this.text = text?.toCharSequence(resources)
 }
 
 @BindingAdapter("android:textAllCaps")
@@ -219,12 +220,12 @@ fun TextView.setTextScaleX(value: Float) {
 }
 
 @BindingAdapter("android:hint")
-fun TextView.setHint(value: Text) {
-    hint = value.toCharSequence()
+fun TextView.setHint(value: Text?) {
+    hint = value?.toCharSequence()
 }
 
 @BindingAdapter("android:textColorHint")
-fun TextView.setHintTextColor(color: Color) = when (color) {
+fun TextView.setHintTextColor(color: Color?) = when (color) {
     is Color.Int -> {
         setHintTextColor(color.rawValue)
     }
@@ -239,6 +240,9 @@ fun TextView.setHintTextColor(color: Color) = when (color) {
     }
     is Color.StateList -> {
         setHintTextColor(color.stateList)
+    }
+    null -> {
+        setHintTextColor(null as ColorStateList?)
     }
 }
 

--- a/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/View.kt
+++ b/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/View.kt
@@ -38,7 +38,7 @@ fun View.setAlpha(value: Float) {
 }
 
 @BindingAdapter("android:background")
-fun View.setBackground(value: Background) = when (value) {
+fun View.setBackground(value: Background?) = when (value) {
     is Background.Color.Int -> {
         setBackgroundColor(value.rawValue)
     }
@@ -73,10 +73,13 @@ fun View.setBackground(value: Background) = when (value) {
     is Background.None -> {
         background = null
     }
+    null -> {
+        background = null
+    }
 }
 
 @BindingAdapter("android:backgroundTint")
-fun View.setBackgroundTint(value: Tint) = when (value) {
+fun View.setBackgroundTint(value: Tint?) = when (value) {
     is Tint.Res -> {
         backgroundTintList = ContextCompat.getColorStateList(context, value.resId)
     }
@@ -86,11 +89,14 @@ fun View.setBackgroundTint(value: Tint) = when (value) {
     is Tint.None -> {
         backgroundTintList = null
     }
+    null -> {
+        backgroundTintList = null
+    }
 }
 
 @BindingAdapter("android:contentDescription")
-fun View.setContentDescription(value: Text) {
-    contentDescription = value.toCharSequence(resources)
+fun View.setContentDescription(value: Text?) {
+    contentDescription = value?.toCharSequence(resources)
 }
 
 @BindingAdapter("android:paddingStart")

--- a/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/ImageViewBindingTest.kt
+++ b/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/ImageViewBindingTest.kt
@@ -173,6 +173,22 @@ class ImageViewBindingTest {
     }
 
     @Test
+    fun testBinding_setImage_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<ImageView>(android.R.id.icon)
+                .setImage(Image.Res(android.R.drawable.ic_btn_speak_now))
+        }
+        onView(withId(android.R.id.icon))
+            .check(matches(withDrawable<BitmapDrawable>()))
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<ImageView>(android.R.id.icon)
+                .setImage(null as Image?)
+        }
+        onView(withId(android.R.id.icon))
+            .check(matches(noDrawable()))
+    }
+
+    @Test
     fun testBinding_setTintList_Res() {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<ImageView>(android.R.id.icon)
@@ -199,6 +215,16 @@ class ImageViewBindingTest {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<ImageView>(android.R.id.icon)
                 .setTintList(Tint.none())
+        }
+        onView(withId(android.R.id.icon))
+            .check(matches(withTintList(null)))
+    }
+
+    @Test
+    fun testBinding_setTintList_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<ImageView>(android.R.id.icon)
+                .setTintList(null as Tint?)
         }
         onView(withId(android.R.id.icon))
             .check(matches(withTintList(null)))

--- a/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/TextViewBindingTest.kt
+++ b/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/TextViewBindingTest.kt
@@ -352,6 +352,21 @@ class TextViewBindingTest {
         onView(withId(android.R.id.text1)).check(matches(withText("Test")))
     }
 
+    @Test
+    fun testBinding_setText_for_null() {
+        onView(withId(android.R.id.text1)).check(matches(withText("")))
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<TextView>(android.R.id.text1)
+                .setText(Text.of("test"))
+        }
+        onView(withId(android.R.id.text1)).check(matches(withText("test")))
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<TextView>(android.R.id.text1)
+                .setText(null as Text?)
+        }
+        onView(withId(android.R.id.text1)).check(matches(withText("")))
+    }
+
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
     fun testBinding_setTextAllCaps_P() {
@@ -459,6 +474,20 @@ class TextViewBindingTest {
     }
 
     @Test
+    fun testBinding_setHint_for_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<TextView>(android.R.id.text1)
+                .setHint(Text.of("test"))
+        }
+        onView(withId(android.R.id.text1)).check(matches(withHint("test")))
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<TextView>(android.R.id.text1)
+                .setHint(null as Text?)
+        }
+        onView(withId(android.R.id.text1)).check(matches(withHint(null)))
+    }
+
+    @Test
     fun testBinding_setHintTextColor_for_Int() {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<TextView>(android.R.id.text1).setTextColor(0)
@@ -525,6 +554,19 @@ class TextViewBindingTest {
                 .setHintTextColor(Color.StateList(stateList))
         }
         onView(withId(android.R.id.text1)).check(matches(withHintTint(stateList)))
+    }
+
+    @Test
+    fun testBinding_setHintTextColor_for_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<TextView>(android.R.id.text1).setTextColor(0)
+        }
+        onView(withId(android.R.id.text1)).check(matches(hasTextColor(0)))
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<TextView>(android.R.id.text1)
+                .setHintTextColor(null as Color?)
+        }
+        onView(withId(android.R.id.text1)).check(matches(noHintColors()))
     }
 
     @Test
@@ -843,6 +885,18 @@ class TextViewBindingTest {
 
             override fun matchesSafely(item: TextView): Boolean {
                 return item.currentHintTextColor == value
+            }
+        }
+    }
+
+    private fun noHintColors(): Matcher<View> {
+        return object : BoundedMatcher<View, TextView>(TextView::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("has no color with state-list")
+            }
+
+            override fun matchesSafely(item: TextView): Boolean {
+                return item.hintTextColors == null
             }
         }
     }

--- a/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/ViewBindingTest.kt
+++ b/testing/src/test/java/net/crimsonwoods/easydatabinding/binding/ViewBindingTest.kt
@@ -142,6 +142,18 @@ class ViewBindingTest {
     }
 
     @Test
+    fun testBinding_setBackground_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<View>(R.id.border)
+                .apply {
+                    setBackgroundColor(Color.RED)
+                    setBackground(null as Background?)
+                }
+        }
+        onView(withId(R.id.border)).check(matches(noBackground()))
+    }
+
+    @Test
     fun testBinding_setBackground_Attr_Drawable() {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<View>(R.id.border)
@@ -194,6 +206,18 @@ class ViewBindingTest {
     }
 
     @Test
+    fun testBinding_setBackgroundTint_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<View>(R.id.border)
+                .apply {
+                    backgroundTintList = ColorStateList.valueOf(Color.RED)
+                    setBackgroundTint(null as Tint?)
+                }
+        }
+        onView(withId(R.id.border)).check(matches(noBackgroundTint()))
+    }
+
+    @Test
     fun testBinding_setContentDescription_Res() {
         scenario.onFragment { fragment ->
             fragment.requireView().findViewById<View>(R.id.border)
@@ -209,6 +233,20 @@ class ViewBindingTest {
                 .setContentDescription(Text.of("test"))
         }
         onView(withId(R.id.border)).check(matches(withContentDescription("test")))
+    }
+
+    @Test
+    fun testBinding_setContentDescription_null() {
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<View>(R.id.border)
+                .contentDescription = "test"
+        }
+        onView(withId(R.id.border)).check(matches(withContentDescription("test")))
+        scenario.onFragment { fragment ->
+            fragment.requireView().findViewById<View>(R.id.border)
+                .setContentDescription(null as Text?)
+        }
+        onView(withId(R.id.border)).check(matches(withContentDescription(null as String?)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

BindingAdapters should support _null_ value.

## Details

Sometimes, `LiveData` has no initial value. So, auto generated binding implementations bind _null_ value and pass it into BindingAdapters. This behavior causes NPE. And expecting that crash is difficult for developer using this library.