### PR TITLE
:up: Update `minSdkVersion` to `23`

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 32
         versionCode 17
         versionName "$version"

--- a/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/Switch.kt
+++ b/lib/src/main/kotlin/net/crimsonwoods/easydatabinding/binding/Switch.kt
@@ -3,9 +3,7 @@
 package net.crimsonwoods.easydatabinding.binding
 
 import android.annotation.SuppressLint
-import android.os.Build
 import android.widget.Switch
-import androidx.annotation.RequiresApi
 import androidx.databinding.BindingAdapter
 import kotlin.math.roundToInt
 import net.crimsonwoods.easydatabinding.models.Bool
@@ -60,16 +58,9 @@ fun Switch.setThumbTextPadding(value: Dimension) {
     thumbTextPadding = value.toPx().roundToInt()
 }
 
-@RequiresApi(value = Build.VERSION_CODES.M)
 @BindingAdapter("android:thumbTint")
 fun Switch.setThumbTintList(value: Tint) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        thumbTintList = value.toColorStateList()
-    } else {
-        throw UnsupportedOperationException(
-            "BindingAdapter for \"android:thumbTint\" attribute is being supported after Android M or later."
-        )
-    }
+    thumbTintList = value.toColorStateList()
 }
 
 @BindingAdapter("android:track")
@@ -77,14 +68,7 @@ fun Switch.setTrackDrawable(value: Drawable) {
     trackDrawable = value.toDrawable()
 }
 
-@RequiresApi(value = Build.VERSION_CODES.M)
 @BindingAdapter("android:trackTint")
 fun Switch.setTrackTintList(value: Tint) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        trackTintList = value.toColorStateList()
-    } else {
-        throw UnsupportedOperationException(
-            "BindingAdapter for \"android:trackTint\" attribute is being supported after Android M or later."
-        )
-    }
+    trackTintList = value.toColorStateList()
 }

--- a/samples/textviewsample/build.gradle
+++ b/samples/textviewsample/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "net.crimsonwoods.easydatabinding.samples.textview"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 32
         versionCode 1
         versionName "1.0"

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 32
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
To support `android:foreground` attribute, needs update `minSdkVersion` to `23`.